### PR TITLE
Create spotlessApply pre-commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,3 +269,16 @@ deploy.targets.roborio.artifacts.frcStaticFileDeploy.dependsOn(writeComputerName
 //             "date.txt"
 //             ).text = outstream
 // }
+
+tasks.register("addPreCommitGitHookOnBuild") {
+    exec {
+        workingDir projectDir
+        if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+            commandLine 'cmd', '/c', 'copy', 'scripts\\pre-commit', '.git\\hooks\\pre-commit'
+        } else {
+            commandLine 'sh', '-c', 'cp scripts/pre-commit .git/hooks/pre-commit'
+        }
+    }
+}
+
+deploy.targets.roborio.artifacts.frcStaticFileDeploy.dependsOn(addPreCommitGitHookOnBuild)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Gather the staged files - to make sure changes are saved only for these files.
+stagedFiles=$(git diff --staged --name-only)
+
+# run spotless apply
+./gradlew spotlessApply
+
+status=$?
+
+if [ "$status" = 0 ] ; then
+    # Add staged file changes to git
+    for file in $stagedFiles; do
+      if test -f "$file"; then
+        git add $file
+      fi
+    done
+    #Exit
+    exit 0
+else
+    echo 1>&2 "Spotless Apply found violations it could not fix."
+    #Exit
+    exit 1
+fi


### PR DESCRIPTION
It's possible to make it so that on build spotlessApply is also executed.

## Justification
Fixes #33 

## Implementaion
Adds a gradle build task and a script that is copied to the local .git/hooks folder.

## Testing Done
Checked that pre-commit is in the .git/hooks folder and it runs `spotlessApply` before a commit. 

## Notes
It's possible to make it so that on build `spotlessApply` is also executed.
Although, that would also require some more work to try and figure out how to get this task running before any other one. Since tasks such as `spotlessCheck` currently run before `spotlessApply` has a chance to run, which makes the build fail.

