### PR TITLE
ignore not having log file

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -58,7 +58,7 @@ public class Robot extends LoggedRobot {
                   LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
         }
       } catch (Exception StringIndexOutOfBoundsException) {
-        System.out.print("No log file found, simulating as normal.");
+        System.out.println("No log file found, simulating as normal.");
       }
     }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -46,16 +46,20 @@ public class Robot extends LoggedRobot {
       Logger.addDataReceiver(new WPILOGWriter()); // Log to a USB stick ("/U/logs")
       Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
       new PowerDistribution(1, ModuleType.kRev); // Enables power distribution logging
-    } else if (IS_REPLAY) {
-      setUseTiming(false); // Run as fast as possible
+    } else {
+      try {
+        String logPath = LogFileUtil.findReplayLog();
+        if (logPath != null) {
+          setUseTiming(false); // Run as fast as possible
 
-      String logPath =
-          LogFileUtil
-              .findReplayLog(); // Pull the replay log from AdvantageScope (or prompt the user)
-      Logger.setReplaySource(new WPILOGReader(logPath)); // Read replay log
-      Logger.addDataReceiver(
-          new WPILOGWriter(
-              LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
+          Logger.setReplaySource(new WPILOGReader(logPath)); // Read replay log
+          Logger.addDataReceiver(
+              new WPILOGWriter(
+                  LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
+        }
+      } catch (Exception StringIndexOutOfBoundsException) {
+        System.out.print("No log file found, simulating as normal.");
+      }
     }
 
     // Logger.disableDeterministicTimestamps() // See "Deterministic Timestamps" in the

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -28,9 +28,6 @@ public class Robot extends LoggedRobot {
 
   private RobotContainer m_robotContainer;
 
-  // TODO : back log card to auto detecting
-  private final boolean IS_REPLAY = false;
-
   /**
    * This function is run when the robot is first started up and should be used for any
    * initialization code.

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.util.NoSuchElementException;
 import org.littletonrobotics.junction.LogFileUtil;
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
@@ -54,8 +55,8 @@ public class Robot extends LoggedRobot {
               new WPILOGWriter(
                   LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
         }
-      } catch (Exception StringIndexOutOfBoundsException) {
-        System.out.println("No log file found, simulating as normal.");
+      } catch (NoSuchElementException | StringIndexOutOfBoundsException ex) {
+        System.out.println("No log file found, simulating as normal. \n");
       }
     }
 


### PR DESCRIPTION
## Justification
Git gives you an error when no log file is provided, and the code itself will prompt you for one if it can't find one. This is annoying, and the bandage for this problem was to have the boolean that you would manually change if you wanted replay mode. This fix makes it so that it catches the error for not having a log file, and just simulates normally if you don't have one.

## Testing Done
I have tested this, and it works