### PR TITLE
Bypass AK log file prompt

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,6 +8,8 @@ import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.NoSuchElementException;
 import org.littletonrobotics.junction.LogFileUtil;
 import org.littletonrobotics.junction.LoggedRobot;
@@ -46,6 +48,13 @@ public class Robot extends LoggedRobot {
       new PowerDistribution(1, ModuleType.kRev); // Enables power distribution logging
     } else {
       try {
+        /*
+        findReplayLog() prompts the user for a log file path to replay, requiring input from the user on the terminal.
+        This is a undesired interaction, so using setIn() to provide an empty line to the prompt.
+
+        findReplayLog() looks for the log file in AdvantageKit first, so this doesn't interrupt our typical use case.
+        */
+        System.setIn(new ByteArrayInputStream("\n".getBytes("UTF-8")));
         String logPath = LogFileUtil.findReplayLog();
         if (logPath != null) {
           setUseTiming(false); // Run as fast as possible
@@ -55,7 +64,9 @@ public class Robot extends LoggedRobot {
               new WPILOGWriter(
                   LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
         }
-      } catch (NoSuchElementException | StringIndexOutOfBoundsException ex) {
+      } catch (NoSuchElementException
+          | StringIndexOutOfBoundsException
+          | UnsupportedEncodingException ex) {
         System.out.println("No log file found, simulating as normal. \n");
       }
     }


### PR DESCRIPTION
<!-- GH PRs use Markdown formatting, see https://www.markdownguide.org/basic-syntax/ -->

## Justification
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
AdvantageKit setup prompts for a log file path to replay on the terminal if it doesn't find one on AdvantageKit. 
This make a confusing user experience for simulation, and is an uncommon use case. 

## Implementaion
<!--- Explain what was done to address the problem/need -->
<!--- Also mention any known or possible side effects -->
Write to System.in to bypass the prompt.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Ran simulation successfully
