### PR TITLE
Add spotless.apply prebuild again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,3 +192,5 @@ test {
     useJUnitPlatform()
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
 }
+
+compileJava.dependsOn("spotlessApply")


### PR DESCRIPTION
<!-- GH PRs use Markdown formatting, see https://www.markdownguide.org/basic-syntax/ -->

## Justification
precommit spotlessApply was removed accidentally


## Implementation
Found the commit and the line by using:
`git log -S spotlessApply build.gradle`

Replaced the line

## Testing Done
Build, watched spotless run again