### PR TITLE
Stop LimelightSubsystem from attempting to get JSON results in sim

### DIFF
--- a/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.LimelightHelpers;
+import frc.robot.Robot;
 import frc.robot.networktables.DebugEntry;
 import java.util.function.BiConsumer;
 
@@ -48,13 +49,15 @@ public class LimelightSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
-    results = LimelightHelpers.getLatestResults("");
+    if (Robot.isReal()) {
+      results = LimelightHelpers.getLatestResults("");
 
-    if (getTagCount() > 1) {
-      measurementsUsed++;
-      measurementConsumer.accept(getPose2d(), getTime());
-      if (measurementsUsed % 100 == 0) {
-        measurementEntry.log(measurementsUsed);
+      if (getTagCount() > 1) {
+        measurementsUsed++;
+        measurementConsumer.accept(getPose2d(), getTime());
+        if (measurementsUsed % 100 == 0) {
+          measurementEntry.log(measurementsUsed);
+        }
       }
     }
   }


### PR DESCRIPTION

<!-- GH PRs use Markdown formatting, see https://www.markdownguide.org/basic-syntax/ -->

## Justification
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
After #13 got merged, simulation prints a ton of "lljson error: ..." lines because there's no Limelight device or simulated version of a Limelight device.

## Implementaion
<!--- Explain what was done to address the problem/need -->
<!--- Also mention any known or possible side effects -->
Block LimelightSubsystem's periodic() method during simulation. i.e. Only update if Robot.isReal() 

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Simulation no longer prints lljson errors.