### PR TITLE
Deleted StaticRobotConfig

### DIFF
--- a/src/main/java/frc/robot/config/StaticRobotConfig.java
+++ b/src/main/java/frc/robot/config/StaticRobotConfig.java
@@ -1,3 +1,0 @@
-package frc.robot.config;
-
-public class StaticRobotConfig {}


### PR DESCRIPTION
<!-- GH PRs use Markdown formatting, see https://www.markdownguide.org/basic-syntax/ -->

## Justification
Addresses Issue #104 Settle StaticRobotConfig vs Constants 

## Implementaion
Deletion of static robot config

## Testing Done
None, the class was unused
