### PR TITLE
Fix CANSparkMaxSim Sendable

### DIFF
--- a/src/main/java/com/revrobotics/CANSparkMaxSim.java
+++ b/src/main/java/com/revrobotics/CANSparkMaxSim.java
@@ -58,28 +58,23 @@ public class CANSparkMaxSim extends CANSparkMax {
       return ret;
     }
 
-    @Override
-    public double getP() {
+    private double getCachedP() {
       return P;
     }
 
-    @Override
-    public double getI() {
+    private double getCachedI() {
       return I;
     }
 
-    @Override
-    public double getD() {
+    private double getCachedD() {
       return D;
     }
 
-    @Override
-    public double getFF() {
+    private double getCachedFF() {
       return FF;
     }
 
-    @Override
-    public double getIZone() {
+    private double getCachedIZone() {
       return IZone;
     }
 
@@ -136,13 +131,13 @@ public class CANSparkMaxSim extends CANSparkMax {
         return;
       }
       builder.setSmartDashboardType("PIDController");
-      builder.addDoubleProperty("p", this::getP, this::setP);
-      builder.addDoubleProperty("i", this::getI, this::setI);
-      builder.addDoubleProperty("d", this::getD, this::setD);
-      builder.addDoubleProperty("ff", this::getFF, this::setFF);
+      builder.addDoubleProperty("p", this::getCachedP, this::setP);
+      builder.addDoubleProperty("i", this::getCachedI, this::setI);
+      builder.addDoubleProperty("d", this::getCachedD, this::setD);
+      builder.addDoubleProperty("ff", this::getCachedFF, this::setFF);
       builder.addDoubleProperty(
           "izone",
-          this::getIZone,
+          this::getCachedIZone,
           (double toSet) -> {
             try {
               setIZone(toSet);

--- a/src/main/java/com/revrobotics/CANSparkMaxSim.java
+++ b/src/main/java/com/revrobotics/CANSparkMaxSim.java
@@ -8,6 +8,7 @@
 package com.revrobotics;
 
 import edu.wpi.first.math.MathSharedStore;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.util.sendable.SendableRegistry;
@@ -254,7 +255,7 @@ public class CANSparkMaxSim extends CANSparkMax {
   @Override
   public void set(double speed) {
     super.set(speed);
-    output = speed;
+    output = MathUtil.clamp(speed, -1, 1);
   }
 
   // Algorithm pulled from https://docs.revrobotics.com/sparkmax/operating-modes/closed-loop-control

--- a/src/main/java/com/revrobotics/CANSparkMaxSim.java
+++ b/src/main/java/com/revrobotics/CANSparkMaxSim.java
@@ -32,11 +32,17 @@ public class CANSparkMaxSim extends CANSparkMax {
 
   public class SparkPIDControllerSim extends SparkPIDController implements Sendable {
     private static int instances = 0;
+    private double P, I, D, FF, IZone;
 
     SparkPIDControllerSim(CANSparkBase device) {
       super(device);
       instances++;
       SendableRegistry.addLW(this, "PIDController", instances);
+      P = super.getP();
+      I = super.getI();
+      D = super.getD();
+      IZone = super.getIZone();
+      FF = super.getFF();
     }
 
     public double getReference() {
@@ -53,7 +59,82 @@ public class CANSparkMaxSim extends CANSparkMax {
     }
 
     @Override
+    public double getP() {
+      return P;
+    }
+
+    @Override
+    public double getI() {
+      return I;
+    }
+
+    @Override
+    public double getD() {
+      return D;
+    }
+
+    @Override
+    public double getFF() {
+      return FF;
+    }
+
+    @Override
+    public double getIZone() {
+      return IZone;
+    }
+
+    @Override
+    public REVLibError setP(double P) {
+      REVLibError ret = super.setP(P);
+      if (ret == REVLibError.kOk) {
+        this.P = P;
+      }
+      return ret;
+    }
+
+    @Override
+    public REVLibError setI(double I) {
+      REVLibError ret = super.setI(I);
+      if (ret == REVLibError.kOk) {
+        this.I = I;
+      }
+      return ret;
+    }
+
+    @Override
+    public REVLibError setD(double D) {
+      REVLibError ret = super.setD(D);
+      if (ret == REVLibError.kOk) {
+        this.D = D;
+      }
+      return ret;
+    }
+
+    @Override
+    public REVLibError setFF(double FF) {
+      REVLibError ret = super.setFF(FF);
+      if (ret == REVLibError.kOk) {
+        this.FF = FF;
+      }
+      return ret;
+    }
+
+    @Override
+    public REVLibError setIZone(double IZone) {
+      REVLibError ret = super.setIZone(IZone);
+      if (ret == REVLibError.kOk) {
+        this.IZone = IZone;
+      }
+      return ret;
+    }
+
+    @Override
     public void initSendable(SendableBuilder builder) {
+
+      // If there are issues with the SparkMAX, don't build widget
+      if (clearFaults() != REVLibError.kOk) {
+        return;
+      }
       builder.setSmartDashboardType("PIDController");
       builder.addDoubleProperty("p", this::getP, this::setP);
       builder.addDoubleProperty("i", this::getI, this::setI);

--- a/src/main/java/com/revrobotics/CANSparkMaxSim.java
+++ b/src/main/java/com/revrobotics/CANSparkMaxSim.java
@@ -251,6 +251,12 @@ public class CANSparkMaxSim extends CANSparkMax {
     return output;
   }
 
+  @Override
+  public void set(double speed) {
+    super.set(speed);
+    output = speed;
+  }
+
   // Algorithm pulled from https://docs.revrobotics.com/sparkmax/operating-modes/closed-loop-control
   private double calculate() {
     if (stopped) {


### PR DESCRIPTION
<!-- GH PRs use Markdown formatting, see https://www.markdownguide.org/basic-syntax/ -->

## Justification
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Slowdown was occurring from CANSparkMaxSim's PIDController widget while testing separate subsystem (i.e. CANSparkMax devices weren't attached). 
Also foreseeing unnecessary reads to SparksMax to update NetworkTable for what should be (mostly) constants when the controllers are actually on the CAN network. 

## Implementaion
<!--- Explain what was done to address the problem/need -->
<!--- Also mention any known or possible side effects -->
Add check to skip building the widget if the CANSparkMax has errors.
Override getters and setters for PIDF control to make sure the values are cached.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested on standalone roboRIO (no SparkMaxs attached). With this addition no longer see "CAN output buffer full" messages for these devices.
