### PR TITLE
Shuffleboard clean up

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -111,7 +111,6 @@ public final class Constants {
 
     public static final int PITCH_MAX_ANGLE_DEGREES = 50;
     public static final int PITCH_MIN_ANGLE_DEGREES = -5;
-
     public static final double PITCH_CONVERSION_FACTOR = 0.25;
     public static final int PITCH_SMART_CURRENT_LIMIT = 40;
 
@@ -157,6 +156,15 @@ public final class Constants {
     public static final int highGearCAN_CODER_ID = 0;
     public static final int lowGearCAN_CODER_ID = 0;
     public static final double ENCODER_ZERO_OFFSET_FROM_TURRET_ZERO_REV = 0;
+    //Turret limits
+    public static final double TURRET_MIN_ANGLE_ROTATIONS =
+        (TURRET_MIN_ANGLE_DEGREES / (360 * TURRET_MOTOR_TURRET_RATIO));
+    public static final double TURRET_MAX_ANGLE_ROTATIONS =
+        (TURRET_MAX_ANGLE_DEGREES / (360 * TURRET_CONVERSION_FACTOR));
+    public static final double PITCH_MIN_ANGLE_ROTATIONS =
+        (PITCH_MIN_ANGLE_DEGREES / (360 * PITCH_CONVERSION_FACTOR));
+    public static final double PITCH_MAX_ANGLE_ROTATIONS =
+        (PITCH_MAX_ANGLE_DEGREES / (360 * PITCH_CONVERSION_FACTOR));
   }
 
   public static class OperatorConstants {
@@ -234,10 +242,10 @@ public final class Constants {
     public static final boolean visionEnabled = true;
     public static final boolean usingPhoton = true;
     public static final boolean elvEnabled = true;
-    public static final boolean signalEnabled = false;
+    public static final boolean signalEnabled = true;
     public static final boolean shooterEnabled = true;
-    public static final boolean triggerEnabled = false;
-    public static final boolean turretEnabled = false;
+    public static final boolean triggerEnabled = true;
+    public static final boolean turretEnabled = true;
   }
 
   public static final int END_GAME_WARNING_TIME = 20;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -156,7 +156,7 @@ public final class Constants {
     public static final int highGearCAN_CODER_ID = 0;
     public static final int lowGearCAN_CODER_ID = 0;
     public static final double ENCODER_ZERO_OFFSET_FROM_TURRET_ZERO_REV = 0;
-    //Turret limits
+    // Turret limits
     public static final double TURRET_MIN_ANGLE_ROTATIONS =
         (TURRET_MIN_ANGLE_DEGREES / (360 * TURRET_MOTOR_TURRET_RATIO));
     public static final double TURRET_MAX_ANGLE_ROTATIONS =

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -7,7 +7,6 @@ package frc.robot.subsystems;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
-import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -16,12 +15,13 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.Constants.IntakeConstants;
 import frc.robot.stateManagement.PlacementMode;
+import frc.robot.utilities.DebugEntry;
 
 public class IntakeSubsystem extends SubsystemBase {
   private TalonFX intakeMotor;
   private CANSparkMax chooserMotor;
-  private GenericEntry intakeOutput;
-  private GenericEntry chooserOutput;
+  private DebugEntry<Double> intakeOutput;
+  private DebugEntry<Double> chooserOutput;
   private ShuffleboardTab intakeTab = Shuffleboard.getTab("Intake");
 
   public IntakeSubsystem() {
@@ -32,8 +32,8 @@ public class IntakeSubsystem extends SubsystemBase {
     chooserMotor.restoreFactoryDefaults();
     // intakeMotor.config
     chooserMotor.setSmartCurrentLimit(20);
-    intakeOutput = intakeTab.add("Intake Motor Output", 0).withPosition(3, 0).getEntry();
-    chooserOutput = intakeTab.add("Chooser Motor Output", 0).withPosition(3, 1).getEntry();
+    intakeOutput = new DebugEntry<Double>(0.0, "Intake Motor Ouput", this);
+    chooserOutput = new DebugEntry<Double>(0.0, "Chooser Motor Output", this);
   }
 
   // TODO: Add check to make sure turret is below 45 degrees before running & add photogate when
@@ -96,8 +96,8 @@ public class IntakeSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
-    intakeOutput.setDouble(intakeMotor.get());
-    chooserOutput.setDouble(chooserMotor.getAppliedOutput());
+    intakeOutput.log(intakeMotor.get());
+    chooserOutput.log(chooserMotor.getAppliedOutput());
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -5,6 +5,7 @@ import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMaxSim;
 import com.revrobotics.RelativeEncoder;
+import com.revrobotics.SparkPIDController;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.GenericEntry;
@@ -51,6 +52,9 @@ public class ShooterSubsystem extends SubsystemBase {
 
   private DebugEntry<Boolean> shooterReadyEntry;
 
+  private DebugEntry<SparkPIDController> leftPID;
+  private DebugEntry<SparkPIDController> rightPID;
+
   private GenericEntry targetRPM = shooterTab.add("Target RPM", 0).getEntry();
   private GenericEntry rightTargetRPM = shooterTab.add("right RPM", 0).getEntry();
   private SpeakerConfig targetSpeeds;
@@ -83,8 +87,12 @@ public class ShooterSubsystem extends SubsystemBase {
     shooterRightMotor.getPIDController().setD(Constants.ShooterConstants.SHOOTER_RIGHT_D);
     shooterRightMotor.getPIDController().setFF(Constants.ShooterConstants.SHOOTER_RIGHT_FF);
 
-    shooterTab.add("Shooter Left Motor PID", shooterLeftMotor.getPIDController());
-    shooterTab.add("Shooter Right Motor PID", shooterRightMotor.getPIDController());
+    leftPID =
+        new DebugEntry<SparkPIDController>(
+            shooterLeftMotor.getPIDController(), "Shooter Left Motor PID", this);
+    rightPID =
+        new DebugEntry<SparkPIDController>(
+            shooterLeftMotor.getPIDController(), "Shooter Right Motor PID", this);
 
     if (Robot.isSimulation()) {
       shooterLeftSim =

--- a/src/main/java/frc/robot/subsystems/TrapElvSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TrapElvSubsystem.java
@@ -271,9 +271,15 @@ public class TrapElvSubsystem extends SubsystemBase {
 
     // SmartDashboard
     TrapElvTab.add("Wrist PID", wristPIDController).withSize(2, 2).withPosition(0, 0);
-    wristP = new TunableNumber("Wrist P", TrapElvConstants.WRIST_PID[0], P -> wristPIDController.setP(P),this);
-    wristI = new TunableNumber("Wrist I", TrapElvConstants.WRIST_PID[1], I -> wristPIDController.setI(I),this);
-    wristD = new TunableNumber("Wrist D", TrapElvConstants.WRIST_PID[2], D -> wristPIDController.setD(D),this);
+    wristP =
+        new TunableNumber(
+            "Wrist P", TrapElvConstants.WRIST_PID[0], P -> wristPIDController.setP(P), this);
+    wristI =
+        new TunableNumber(
+            "Wrist I", TrapElvConstants.WRIST_PID[1], I -> wristPIDController.setI(I), this);
+    wristD =
+        new TunableNumber(
+            "Wrist D", TrapElvConstants.WRIST_PID[2], D -> wristPIDController.setD(D), this);
 
     sourceLog = new DebugEntry<Boolean>(sourceBreak.get(), "Source Beam Break", this);
     groundLog = new DebugEntry<Boolean>(groundBreak.get(), "Ground Beam Break", this);

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -129,18 +129,28 @@ public class TurretSubsystem extends SubsystemBase {
     turretPIDController.setIZone(Constants.TurretConstants.TURRET_KIZ);
     turretP =
         new TunableNumber(
-            "Turret P", Constants.TurretConstants.TURRET_KP, p -> turretPIDController.setP(p), this);
+            "Turret P",
+            Constants.TurretConstants.TURRET_KP,
+            p -> turretPIDController.setP(p),
+            this);
     turretI =
         new TunableNumber(
-            "Turret I", Constants.TurretConstants.TURRET_KI, i -> turretPIDController.setI(i), this);
+            "Turret I",
+            Constants.TurretConstants.TURRET_KI,
+            i -> turretPIDController.setI(i),
+            this);
     turretD =
         new TunableNumber(
-            "Turret D", Constants.TurretConstants.TURRET_KD, d -> turretPIDController.setD(d), this);
+            "Turret D",
+            Constants.TurretConstants.TURRET_KD,
+            d -> turretPIDController.setD(d),
+            this);
     turretIZ =
         new TunableNumber(
             "Turret IZ",
             Constants.TurretConstants.TURRET_KIZ,
-            iz -> turretPIDController.setIZone(iz), this);
+            iz -> turretPIDController.setIZone(iz),
+            this);
 
     pitchMotor = new CANSparkMaxSim(Constants.TurretConstants.PITCH_MOTOR_ID, MotorType.kBrushless);
     pitchMotor.restoreFactoryDefaults();
@@ -170,7 +180,8 @@ public class TurretSubsystem extends SubsystemBase {
         new TunableNumber(
             "Pitch IZ",
             Constants.TurretConstants.TURRET_KIZ,
-            iz -> turretPIDController.setIZone(iz), this);
+            iz -> turretPIDController.setIZone(iz),
+            this);
     pitchFeedForward =
         new ArmFeedforward(
             Constants.TurretConstants.PITCH_KS,

--- a/src/main/java/frc/robot/utilities/TunableNumber.java
+++ b/src/main/java/frc/robot/utilities/TunableNumber.java
@@ -3,17 +3,19 @@ package frc.robot.utilities;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
 import java.util.function.Consumer;
 
 public class TunableNumber extends SubsystemBase {
-  private static ShuffleboardTab tuningTab = Shuffleboard.getTab("Tuning");
+  private static ShuffleboardTab tuningTab;
   private GenericEntry numberEntry;
   private double value;
   private Consumer<Double> consumer;
 
-  public TunableNumber(String name, double defaultValue, Consumer<Double> consumer) {
+  public TunableNumber(String name, double defaultValue, Consumer<Double> consumer, Subsystem subsystem) {
+    tuningTab = Shuffleboard.getTab(subsystem.getName());
     this.value = defaultValue;
     this.consumer = consumer;
     if (!Robot.isCompetition) {

--- a/src/main/java/frc/robot/utilities/TunableNumber.java
+++ b/src/main/java/frc/robot/utilities/TunableNumber.java
@@ -14,7 +14,8 @@ public class TunableNumber extends SubsystemBase {
   private double value;
   private Consumer<Double> consumer;
 
-  public TunableNumber(String name, double defaultValue, Consumer<Double> consumer, Subsystem subsystem) {
+  public TunableNumber(
+      String name, double defaultValue, Consumer<Double> consumer, Subsystem subsystem) {
     tuningTab = Shuffleboard.getTab(subsystem.getName());
     this.value = defaultValue;
     this.consumer = consumer;


### PR DESCRIPTION
## Justification
Shuffleboard is messy, and during comp, we want all unimportant data to be logged, not sent to network tables, so we change everything that is not important to be a debug entry.