### PR TITLE
Tunnable number subscribers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,12 @@ deploy {
 
                 frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
                     // Unomment to enable VisualVM connection
-                    jvmArgs.add("-Dcom.sun.management.jmxremote=true")
-                    jvmArgs.add("-Dcom.sun.management.jmxremote.port=1198")
-                    jvmArgs.add("-Dcom.sun.management.jmxremote.local.only=false")
-                    jvmArgs.add("-Dcom.sun.management.jmxremote.ssl=false")
-                    jvmArgs.add("-Dcom.sun.management.jmxremote.authenticate=false")
-                    jvmArgs.add("-Djava.rmi.server.hostname=10.63.77.2") // Replace XX.XX with team number
+                    // jvmArgs.add("-Dcom.sun.management.jmxremote=true")
+                    // jvmArgs.add("-Dcom.sun.management.jmxremote.port=1198")
+                    // jvmArgs.add("-Dcom.sun.management.jmxremote.local.only=false")
+                    // jvmArgs.add("-Dcom.sun.management.jmxremote.ssl=false")
+                    // jvmArgs.add("-Dcom.sun.management.jmxremote.authenticate=false")
+                    // jvmArgs.add("-Djava.rmi.server.hostname=10.63.77.2") // Replace XX.XX with team number
                 }
 
                 // Static files artifact

--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,12 @@ deploy {
 
                 frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
                     // Unomment to enable VisualVM connection
-                    // jvmArgs.add("-Dcom.sun.management.jmxremote=true")
-                    // jvmArgs.add("-Dcom.sun.management.jmxremote.port=1198")
-                    // jvmArgs.add("-Dcom.sun.management.jmxremote.local.only=false")
-                    // jvmArgs.add("-Dcom.sun.management.jmxremote.ssl=false")
-                    // jvmArgs.add("-Dcom.sun.management.jmxremote.authenticate=false")
-                    // jvmArgs.add("-Djava.rmi.server.hostname=10.63.77.2") // Replace XX.XX with team number
+                    jvmArgs.add("-Dcom.sun.management.jmxremote=true")
+                    jvmArgs.add("-Dcom.sun.management.jmxremote.port=1198")
+                    jvmArgs.add("-Dcom.sun.management.jmxremote.local.only=false")
+                    jvmArgs.add("-Dcom.sun.management.jmxremote.ssl=false")
+                    jvmArgs.add("-Dcom.sun.management.jmxremote.authenticate=false")
+                    jvmArgs.add("-Djava.rmi.server.hostname=10.63.77.2") // Replace XX.XX with team number
                 }
 
                 // Static files artifact

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -29,7 +29,7 @@ import org.littletonrobotics.junction.wpilog.WPILOGWriter;
  * project.
  */
 public class Robot extends LoggedRobot {
-  public static final boolean isCompetition = true;
+  public static final boolean isCompetition = false;
 
   private Command m_autonomousCommand;
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -29,7 +29,7 @@ import org.littletonrobotics.junction.wpilog.WPILOGWriter;
  * project.
  */
 public class Robot extends LoggedRobot {
-  public static final boolean isCompetition = false;
+  public static final boolean isCompetition = true;
 
   private Command m_autonomousCommand;
 

--- a/src/main/java/frc/robot/subsystems/shooterSubsystem/ShooterCommandFactory.java
+++ b/src/main/java/frc/robot/subsystems/shooterSubsystem/ShooterCommandFactory.java
@@ -62,7 +62,7 @@ public class ShooterCommandFactory {
     return new FunctionalCommand(
             () -> {
               subsystem.setShooterSpeeds(
-                  new SpeakerConfig(-1, leftTargetRPM.get(), rightTargetRPM.get()));
+                  new SpeakerConfig(-1, leftTargetRPM.getAsDouble(), rightTargetRPM.getAsDouble()));
             },
             () -> {},
             (a) -> {},

--- a/src/main/java/frc/robot/subsystems/shooterSubsystem/ShooterCommandFactory.java
+++ b/src/main/java/frc/robot/subsystems/shooterSubsystem/ShooterCommandFactory.java
@@ -62,7 +62,7 @@ public class ShooterCommandFactory {
     return new FunctionalCommand(
             () -> {
               subsystem.setShooterSpeeds(
-                  new SpeakerConfig(-1, leftTargetRPM.getAsDouble(), rightTargetRPM.getAsDouble()));
+                  new SpeakerConfig(-1, leftTargetRPM.get(), rightTargetRPM.get()));
             },
             () -> {},
             (a) -> {},

--- a/src/main/java/frc/robot/utilities/TunableNumber.java
+++ b/src/main/java/frc/robot/utilities/TunableNumber.java
@@ -4,9 +4,7 @@ import edu.wpi.first.networktables.DoubleSubscriber;
 import edu.wpi.first.networktables.DoubleTopic;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.networktables.PubSub;
 import edu.wpi.first.networktables.PubSubOption;
-import edu.wpi.first.networktables.Topic;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Subsystem;
@@ -39,9 +37,11 @@ public class TunableNumber extends SubsystemBase implements DoubleSupplier {
       inst = NetworkTableInstance.getDefault();
       numberEntry = tuningTab.add(name, defaultValue).getEntry();
       numberEntry.close();
-      
+
       doubleTopic = inst.getDoubleTopic(name);
-      doubleSub = doubleTopic.subscribe(defaultValue, PubSubOption.pollStorage(0), PubSubOption.periodic(1));
+      doubleSub =
+          doubleTopic.subscribe(
+              defaultValue, PubSubOption.pollStorage(0), PubSubOption.periodic(1));
     }
   }
 

--- a/src/main/java/frc/robot/utilities/TunableNumber.java
+++ b/src/main/java/frc/robot/utilities/TunableNumber.java
@@ -2,7 +2,6 @@ package frc.robot.utilities;
 
 import edu.wpi.first.networktables.DoubleSubscriber;
 import edu.wpi.first.networktables.DoubleTopic;
-import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
@@ -14,13 +13,12 @@ import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 
 public class TunableNumber extends SubsystemBase implements DoubleSupplier {
-  private NetworkTableInstance inst;
+  private static NetworkTableInstance inst;
   private static ShuffleboardTab tuningTab;
-  private GenericEntry numberEntry;
+
   private double value;
   private double defaultValue;
   private Consumer<Double> consumer;
-
   private DoubleTopic doubleTopic;
   private DoubleSubscriber doubleSub;
 
@@ -32,23 +30,24 @@ public class TunableNumber extends SubsystemBase implements DoubleSupplier {
       String name, double defaultValue, Consumer<Double> consumer, Subsystem subsystem) {
     tuningTab = Shuffleboard.getTab(subsystem.getName());
     this.value = defaultValue;
+    this.defaultValue = defaultValue;
     this.consumer = consumer;
+
     if (!Robot.isCompetition) {
       inst = NetworkTableInstance.getDefault();
-      numberEntry = tuningTab.add(name, defaultValue).getEntry();
-      numberEntry.close();
+      tuningTab.add(name, this.defaultValue);
 
       doubleTopic = inst.getDoubleTopic(name);
       doubleSub =
           doubleTopic.subscribe(
-              defaultValue, PubSubOption.pollStorage(0), PubSubOption.periodic(1));
+              this.defaultValue, PubSubOption.pollStorage(0), PubSubOption.periodic(1));
     }
   }
 
   public void periodic() {
     if (!Robot.isCompetition) {
-      consumer.accept(doubleSub.get(defaultValue));
-      value = doubleSub.get(defaultValue);
+      value = doubleSub.get(this.defaultValue);
+      consumer.accept(value);
     }
   }
 

--- a/src/main/java/frc/robot/utilities/TunableNumber.java
+++ b/src/main/java/frc/robot/utilities/TunableNumber.java
@@ -1,9 +1,6 @@
 package frc.robot.utilities;
 
-import edu.wpi.first.networktables.DoubleSubscriber;
-import edu.wpi.first.networktables.DoubleTopic;
 import edu.wpi.first.networktables.GenericEntry;
-import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Subsystem;
@@ -13,15 +10,10 @@ import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 
 public class TunableNumber extends SubsystemBase implements DoubleSupplier {
-  private NetworkTableInstance inst;
   private static ShuffleboardTab tuningTab;
   private GenericEntry numberEntry;
   private double value;
-  private double defaultValue;
   private Consumer<Double> consumer;
-
-  private DoubleTopic doubleTopic;
-  private DoubleSubscriber doubleSub;
 
   public TunableNumber(String name, double defaultValue, Subsystem subsystem) {
     this(name, defaultValue, (ignored) -> {}, subsystem);
@@ -33,18 +25,19 @@ public class TunableNumber extends SubsystemBase implements DoubleSupplier {
     this.value = defaultValue;
     this.consumer = consumer;
     if (!Robot.isCompetition) {
-      inst = NetworkTableInstance.getDefault();
       numberEntry = tuningTab.add(name, defaultValue).getEntry();
-      doubleTopic = inst.getDoubleTopic(name);
-      doubleSub = doubleTopic.subscribe(defaultValue);
     }
   }
 
   public void periodic() {
     if (!Robot.isCompetition) {
-      consumer.accept(doubleSub.get(defaultValue));
-      value = doubleSub.get(defaultValue);
+      consumer.accept(numberEntry.getDouble(value));
+      value = numberEntry.getDouble(value);
     }
+  }
+
+  public double get() {
+    return value;
   }
 
   public double getAsDouble() {

--- a/src/main/java/frc/robot/utilities/TunableNumber.java
+++ b/src/main/java/frc/robot/utilities/TunableNumber.java
@@ -4,6 +4,9 @@ import edu.wpi.first.networktables.DoubleSubscriber;
 import edu.wpi.first.networktables.DoubleTopic;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSub;
+import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.networktables.Topic;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Subsystem;
@@ -35,8 +38,10 @@ public class TunableNumber extends SubsystemBase implements DoubleSupplier {
     if (!Robot.isCompetition) {
       inst = NetworkTableInstance.getDefault();
       numberEntry = tuningTab.add(name, defaultValue).getEntry();
+      numberEntry.close();
+      
       doubleTopic = inst.getDoubleTopic(name);
-      doubleSub = doubleTopic.subscribe(defaultValue);
+      doubleSub = doubleTopic.subscribe(defaultValue, PubSubOption.pollStorage(0), PubSubOption.periodic(1));
     }
   }
 


### PR DESCRIPTION
<!-- GH PRs use Markdown formatting, see https://www.markdownguide.org/basic-syntax/ -->

## Justification
Tunable numbers have been taking up too much CPU, so we are making use of Subscribers rather than periodically pulling from NT.

## Testing Done
Needs to be testing on real robot, but has been simulated, and seems to be working.
