### PR TITLE
Add Tag searching for when Odometry Fails

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -10,6 +10,8 @@ import edu.wpi.first.math.util.Units;
 import frc.robot.subsystems.shooterSubsystem.ShooterSubsystem.SpeakerConfig;
 import frc.robot.utilities.HowdyFF;
 import frc.robot.utilities.HowdyPID;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
@@ -108,6 +110,7 @@ public final class Constants {
 
     public static final int TURRET_MIN_ANGLE_DEGREES = -90;
     public static final int TURRET_MAX_ANGLE_DEGREES = 90;
+    public static final double TURRET_ALLOWED_ERROR = 2.5;
 
     public static final double TURRET_CONVERSION_FACTOR = 15 / 82d;
     public static final int TURRET_SMART_CURRENT_LIMIT = 60;
@@ -175,6 +178,9 @@ public final class Constants {
     public static final double PITCH_MAX_ANGLE_ROTATIONS =
         ((PITCH_MAX_ANGLE_DEGREES * PITCH_CONVERSION_FACTOR) / 360);
     public static final Rotation2d ALLOWED_PIN_ERROR = Rotation2d.fromDegrees(2);
+
+    public static final ArrayDeque<Double> TURRET_SCAN_POINTS =
+        new ArrayDeque<Double>(Arrays.asList(0.0, 45.0, -45.0));
 
     public static final TurretDataPoint[] TURRET_DATA = {
       // Verified 5/5

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -110,7 +110,7 @@ public final class Constants {
 
     public static final int TURRET_MIN_ANGLE_DEGREES = -90;
     public static final int TURRET_MAX_ANGLE_DEGREES = 90;
-    public static final double TURRET_ALLOWED_ERROR = 2.5;
+    public static final double TURRET_ALLOWED_ERROR = 20;
 
     public static final double TURRET_CONVERSION_FACTOR = 15 / 82d;
     public static final int TURRET_SMART_CURRENT_LIMIT = 60;

--- a/src/main/java/frc/robot/subsystems/turretSubsystem/TurretCommandFactory.java
+++ b/src/main/java/frc/robot/subsystems/turretSubsystem/TurretCommandFactory.java
@@ -7,8 +7,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.interpolation.InterpolatingDoubleTreeMap;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
@@ -155,6 +153,7 @@ public class TurretCommandFactory {
 
   public Command longRangeShot() {
     if (subsystem == null) return Commands.none();
+
     return subsystem
         .runEnd(
             () -> {
@@ -215,46 +214,10 @@ public class TurretCommandFactory {
           // Check if there is vision
           if (Double.isNaN(errDegrees)) {
             // If not vision, use Odometry
-            if (!subsystem.getLastChance()) {
-              // Get error of the angle from Odometry
-              double odometryTurretAim =
-                  searchingBehavior.get().getRotations() + subsystem.getTurretPos();
-
-              // If the error is in range of the allowed error, move on the Pigeon,
-              // bc there is still no vision at this point
-              if (Math.abs(odometryTurretAim)
-                  <= Units.degreesToRotations(TurretConstants.TURRET_ALLOWED_ERROR))
-                subsystem.setLastChance();
-
-              // return the error
-              return odometryTurretAim;
-
-              // If Odometry Fails, use Pigeon Scan Method
-            } else {
-              // Get the error of turret to point at speaker side of feild,
-              // or what ever scan point it's at
-              double pigeonTurretAim =
-                  /*(-TunerConstants.drivetrain.getPigeon2().getRotation2d().getRotations()
-                      + subsystem.getTurretPos())
-                  + */ TurretConstants.TURRET_SCAN_POINTS.getFirst();
-              // account for what allience color we are on TODO: check if this color is right
-              if (DriverStation.getAlliance().equals(DriverStation.Alliance.Blue))
-                pigeonTurretAim += Units.degreesToRotations(180);
-
-              // If the set angle from the pigeon is in the allowed error range,
-              // move on to the next scan point
-              if (Math.abs(pigeonTurretAim)
-                  <= Units.degreesToRotations(TurretConstants.TURRET_ALLOWED_ERROR)) {
-                TurretConstants.TURRET_SCAN_POINTS.addLast(
-                    TurretConstants.TURRET_SCAN_POINTS.getFirst());
-                TurretConstants.TURRET_SCAN_POINTS.removeFirst();
-              }
-              SmartDashboard.putNumber(
-                  "current goal", TurretConstants.TURRET_SCAN_POINTS.getFirst());
-
-              // Return the error
-              return pigeonTurretAim;
-            }
+            // Get error of the angle from Odometry
+            double odometryTurretAim =
+                searchingBehavior.get().getRotations() + subsystem.getTurretPos();
+            return odometryTurretAim;
           }
           return Units.degreesToRotations(errDegrees);
         });

--- a/src/main/java/frc/robot/subsystems/turretSubsystem/TurretCommandFactory.java
+++ b/src/main/java/frc/robot/subsystems/turretSubsystem/TurretCommandFactory.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.interpolation.InterpolatingDoubleTreeMap;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
@@ -16,7 +17,6 @@ import frc.robot.Constants;
 import frc.robot.Constants.LimelightConstants;
 import frc.robot.Constants.TurretConstants;
 import frc.robot.Constants.TurretDataPoint;
-import frc.robot.config.TunerConstants;
 import frc.robot.stateManagement.AllianceColor;
 import frc.robot.stateManagement.RobotStateManager;
 import frc.robot.subsystems.vision.VisionSubsystem;
@@ -214,7 +214,7 @@ public class TurretCommandFactory {
 
           // Check if there is vision
           if (Double.isNaN(errDegrees)) {
-            // If not vison, use Odometry
+            // If not vision, use Odometry
             if (!subsystem.getLastChance()) {
               // Get error of the angle from Odometry
               double odometryTurretAim =
@@ -222,7 +222,7 @@ public class TurretCommandFactory {
 
               // If the error is in range of the allowed error, move on the Pigeon,
               // bc there is still no vision at this point
-              if (odometryTurretAim
+              if (Math.abs(odometryTurretAim)
                   <= Units.degreesToRotations(TurretConstants.TURRET_ALLOWED_ERROR))
                 subsystem.setLastChance();
 
@@ -234,21 +234,23 @@ public class TurretCommandFactory {
               // Get the error of turret to point at speaker side of feild,
               // or what ever scan point it's at
               double pigeonTurretAim =
-                  (-TunerConstants.drivetrain.getPigeon2().getRotation2d().getRotations()
-                          + subsystem.getTurretPos())
-                      + TurretConstants.TURRET_SCAN_POINTS.getFirst();
+                  /*(-TunerConstants.drivetrain.getPigeon2().getRotation2d().getRotations()
+                      + subsystem.getTurretPos())
+                  + */ TurretConstants.TURRET_SCAN_POINTS.getFirst();
               // account for what allience color we are on TODO: check if this color is right
               if (DriverStation.getAlliance().equals(DriverStation.Alliance.Blue))
                 pigeonTurretAim += Units.degreesToRotations(180);
 
               // If the set angle from the pigeon is in the allowed error range,
               // move on to the next scan point
-              if (pigeonTurretAim
+              if (Math.abs(pigeonTurretAim)
                   <= Units.degreesToRotations(TurretConstants.TURRET_ALLOWED_ERROR)) {
                 TurretConstants.TURRET_SCAN_POINTS.addLast(
                     TurretConstants.TURRET_SCAN_POINTS.getFirst());
                 TurretConstants.TURRET_SCAN_POINTS.removeFirst();
               }
+              SmartDashboard.putNumber(
+                  "current goal", TurretConstants.TURRET_SCAN_POINTS.getFirst());
 
               // Return the error
               return pigeonTurretAim;

--- a/src/main/java/frc/robot/subsystems/turretSubsystem/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turretSubsystem/TurretSubsystem.java
@@ -385,6 +385,7 @@ public class TurretSubsystem extends SubsystemBase {
       updateTurretPosition();
       double positionError = positionErrorSupplier.getAsDouble();
       positionErrorLog.log(positionError);
+      turretGoalPositionEntry.log(turretPosition + positionError);
 
       final double targetVelocity = turretPositionPIDController.calculate(positionError);
       final double motorOut = turretVelocityPIDController.calculate(getTurretVel(), targetVelocity);

--- a/src/main/java/frc/robot/subsystems/turretSubsystem/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turretSubsystem/TurretSubsystem.java
@@ -30,6 +30,7 @@ import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -37,11 +38,11 @@ import frc.robot.Constants;
 import frc.robot.Constants.TurretConstants;
 import frc.robot.Constants.enabledSubsystems;
 import frc.robot.Robot;
+import frc.robot.config.TunerConstants;
 import frc.robot.stateManagement.RobotStateManager;
 import frc.robot.subsystems.vision.VisionSubsystem;
 import frc.robot.utilities.DebugEntry;
 import frc.robot.utilities.HowdyMath;
-import java.util.Iterator;
 import java.util.function.DoubleSupplier;
 
 public class TurretSubsystem extends SubsystemBase {
@@ -95,16 +96,16 @@ public class TurretSubsystem extends SubsystemBase {
       new DebugEntry<String>("none", "Turret Command", this);
   private DebugEntry<Double> pitchMotorOutput =
       new DebugEntry<Double>(0.0, "Pitch Motor Output", this);
-
   private DebugEntry<Double> positionErrorLog =
       new DebugEntry<Double>(0.0, "Position Error (deg?)", this);
-
   private DebugEntry<Double> targetVelocityLog =
       new DebugEntry<Double>(0.0, "Target Velocity (RPM)", this);
 
+  private DebugEntry<Boolean> isLastChanceLog =
+      new DebugEntry<Boolean>(false, "isLastChance", this);
+
   private boolean usingPitchPid = true;
   private final PIDController turretVelocityPIDController;
-  private Iterator<Double> currentScanPoint;
   private boolean isLastChance;
 
   public TurretSubsystem(RobotStateManager robotStateManager, VisionSubsystem visionSubsystem) {
@@ -163,7 +164,6 @@ public class TurretSubsystem extends SubsystemBase {
     highGearCANcoder.getConfigurator().apply(highGearSensorConfigs);
     lowGearCANcoder.getConfigurator().apply(lowGearSensorConfigs);
 
-    currentScanPoint = TurretConstants.TURRET_SCAN_POINTS.iterator();
     isLastChance = false;
 
     // Simulation
@@ -381,6 +381,7 @@ public class TurretSubsystem extends SubsystemBase {
   @Override
   public void periodic() {
     if (enabledSubsystems.turretRotationEnabled) {
+      SmartDashboard.putNumber("Pigeon Angle", TunerConstants.drivetrain.getPigeon2().getAngle());
       updateTurretPosition();
       double positionError = positionErrorSupplier.getAsDouble();
       positionErrorLog.log(positionError);
@@ -471,10 +472,12 @@ public class TurretSubsystem extends SubsystemBase {
 
   public void setLastChance() {
     isLastChance = true;
+    isLastChanceLog.log(isLastChance);
   }
 
   public void resetLastChance() {
     isLastChance = false;
+    isLastChanceLog.log(isLastChance);
   }
 
   public boolean getLastChance() {

--- a/src/main/java/frc/robot/subsystems/turretSubsystem/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turretSubsystem/TurretSubsystem.java
@@ -41,6 +41,7 @@ import frc.robot.stateManagement.RobotStateManager;
 import frc.robot.subsystems.vision.VisionSubsystem;
 import frc.robot.utilities.DebugEntry;
 import frc.robot.utilities.HowdyMath;
+import java.util.Iterator;
 import java.util.function.DoubleSupplier;
 
 public class TurretSubsystem extends SubsystemBase {
@@ -103,6 +104,8 @@ public class TurretSubsystem extends SubsystemBase {
 
   private boolean usingPitchPid = true;
   private final PIDController turretVelocityPIDController;
+  private Iterator<Double> currentScanPoint;
+  private boolean isLastChance;
 
   public TurretSubsystem(RobotStateManager robotStateManager, VisionSubsystem visionSubsystem) {
     this.positionErrorSupplier = () -> 0;
@@ -159,6 +162,9 @@ public class TurretSubsystem extends SubsystemBase {
 
     highGearCANcoder.getConfigurator().apply(highGearSensorConfigs);
     lowGearCANcoder.getConfigurator().apply(lowGearSensorConfigs);
+
+    currentScanPoint = TurretConstants.TURRET_SCAN_POINTS.iterator();
+    isLastChance = false;
 
     // Simulation
     if (Robot.isSimulation()) {
@@ -461,5 +467,17 @@ public class TurretSubsystem extends SubsystemBase {
     boolean result = pitchPIDController.atSetpoint();
     atPitchLog.log(result);
     return result;
+  }
+
+  public void setLastChance() {
+    isLastChance = true;
+  }
+
+  public void resetLastChance() {
+    isLastChance = false;
+  }
+
+  public boolean getLastChance() {
+    return isLastChance;
   }
 }


### PR DESCRIPTION
## Justification
We need a last-chance option for when our odometry fails us, and we still need to score. Odometry normally gets messed up when we are being defended by other robots (which happens a lot at comp), and this causes the turret to calculate where it should be shooting wrongfully.

## Implementaion
The idea for this implementation is that the turret will first use the Pigeon2 on the robot as a gyro to point toward the general speaker side of the field, if it does not find an April tag there, we move to 2 other setpoints that are 45 degrees in each direction of were the Pigeon says we would go. This covers most cases, and the driver is mostlikey going to face that general direction
